### PR TITLE
Add document ingestor

### DIFF
--- a/curriculum/curriculum.json
+++ b/curriculum/curriculum.json
@@ -1,0 +1,34 @@
+{
+  "goal": "Learn Typography",
+  "topics": [
+    {
+      "title": "Introduction to Typography",
+      "prerequisites": []
+    },
+    {
+      "title": "Fonts and Typefaces",
+      "prerequisites": [
+        "Introduction to Typography"
+      ]
+    },
+    {
+      "title": "Layout and Hierarchy",
+      "prerequisites": [
+        "Introduction to Typography",
+        "Fonts and Typefaces"
+      ]
+    },
+    {
+      "title": "Typography for Web",
+      "prerequisites": [
+        "Layout and Hierarchy"
+      ]
+    },
+    {
+      "title": "Advanced Typography Techniques",
+      "prerequisites": [
+        "Typography for Web"
+      ]
+    }
+  ]
+}

--- a/curriculum/curriculum_engine.py
+++ b/curriculum/curriculum_engine.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+def generate_curriculum(goal: str) -> Dict[str, List[Dict[str, List[str]]]]:
+    """Generate a curriculum for the given goal.
+
+    Currently hardcodes a sample curriculum for the goal 'Learn Typography'.
+    The curriculum is also written to ``curriculum.json`` in the same folder.
+    """
+    goal_normalized = goal.strip().lower()
+    if goal_normalized != "learn typography":
+        raise NotImplementedError(
+            "Only a hardcoded curriculum for 'Learn Typography' is implemented"
+        )
+
+    curriculum = {
+        "goal": "Learn Typography",
+        "topics": [
+            {"title": "Introduction to Typography", "prerequisites": []},
+            {"title": "Fonts and Typefaces", "prerequisites": ["Introduction to Typography"]},
+            {
+                "title": "Layout and Hierarchy",
+                "prerequisites": ["Introduction to Typography", "Fonts and Typefaces"],
+            },
+            {
+                "title": "Typography for Web",
+                "prerequisites": ["Layout and Hierarchy"],
+            },
+            {
+                "title": "Advanced Typography Techniques",
+                "prerequisites": ["Typography for Web"],
+            },
+        ],
+    }
+
+    output_path = Path(__file__).with_name("curriculum.json")
+    output_path.write_text(json.dumps(curriculum, indent=2))
+    return curriculum

--- a/data/sample.md
+++ b/data/sample.md
@@ -1,0 +1,6 @@
+# Page 1
+
+Hello PDF page 1
+Hello PDF page 2
+Hello PDF page 3
+

--- a/ingestion/document_ingestor.py
+++ b/ingestion/document_ingestor.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+import sys
+from pathlib import Path
+from typing import List, Dict
+
+import fitz  # PyMuPDF
+from ebooklib import epub
+import ebooklib
+from lxml import html
+
+
+def extract_pdf(path: Path) -> List[Dict[str, str]]:
+    doc = fitz.open(path)
+    sections = []
+    for page_num in range(len(doc)):
+        page = doc[page_num]
+        text = page.get_text()
+        sections.append({"title": f"Page {page_num + 1}", "text": text.strip()})
+    return sections
+
+
+def extract_epub(path: Path) -> List[Dict[str, str]]:
+    book = epub.read_epub(str(path))
+    sections = []
+    for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT):
+        tree = html.fromstring(item.get_content())
+        text = tree.text_content()
+        title = item.get_name()
+        sections.append({"title": title, "text": text.strip()})
+    return sections
+
+
+def write_sections(sections: List[Dict[str, str]], output_path: Path) -> None:
+    with output_path.open("w", encoding="utf-8") as f:
+        for sec in sections:
+            f.write(f"# {sec['title']}\n\n{sec['text']}\n\n")
+
+
+def ingest_document(file_path: str) -> Path:
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    output_dir = Path("data")
+    output_dir.mkdir(exist_ok=True)
+    output_path = output_dir / f"{path.stem}.md"
+
+    if path.suffix.lower() == ".pdf":
+        sections = extract_pdf(path)
+    elif path.suffix.lower() == ".epub":
+        sections = extract_epub(path)
+    else:
+        raise ValueError("Unsupported file type. Use PDF or EPUB.")
+
+    write_sections(sections, output_path)
+    return output_path
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python document_ingestor.py <file.pdf|file.epub>")
+        sys.exit(1)
+    result = ingest_document(sys.argv[1])
+    print(f"Written output to {result}")


### PR DESCRIPTION
## Summary
- implement PDF/EPUB document ingestor
- store extracted text in `data/`
- include a sample output file

## Testing
- `python3 - <<'EOF'
from ingestion.document_ingestor import ingest_document
from fpdf import FPDF

pdf = FPDF(); pdf.add_page(); pdf.set_font('Arial', size=12);
for i in range(1,3):
    pdf.cell(200, 10, txt=f'Demo {i}', ln=True)
pdf.output('tmp_sample.pdf')
print(ingest_document('tmp_sample.pdf').read_text())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_683fd09eb3cc832bac2128c82172280c