### PR TITLE
Add flashcard generator stub

### DIFF
--- a/learning/flashcard_gen.py
+++ b/learning/flashcard_gen.py
@@ -1,0 +1,48 @@
+import json
+import re
+from pathlib import Path
+from typing import List, Dict
+
+
+def generate_flashcards(text_chunk: str) -> List[Dict[str, str]]:
+    """Stub to generate example flashcards from *text_chunk*.
+
+    In a real application this would call an LLM to create question/answer
+    pairs. This stub extracts up to five sentences from the input text and
+    uses them to create simple flashcards.
+    """
+    # Break the text into sentences
+    sentences = [s.strip() for s in re.split(r'[.!?]', text_chunk) if s.strip()]
+
+    flashcards: List[Dict[str, str]] = []
+    for i, sentence in enumerate(sentences[:5], start=1):
+        question = f"What does the text say about: '{sentence[:40]}'?"
+        flashcards.append({"question": question, "answer": sentence})
+
+    # Pad with example cards if fewer than five sentences were found
+    while len(flashcards) < 5:
+        n = len(flashcards) + 1
+        flashcards.append({"question": f"Example question {n}", "answer": f"Example answer {n}"})
+
+    return flashcards
+
+
+def main() -> None:
+    """Generate flashcards from a text file."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate flashcards from a text file")
+    parser.add_argument("input_file", help="Path to the text file")
+    parser.add_argument("--output", default="flashcards.json", help="Output JSON file")
+    args = parser.parse_args()
+
+    text = Path(args.input_file).read_text(encoding="utf-8")
+    cards = generate_flashcards(text)
+
+    out_path = Path(args.output)
+    out_path.write_text(json.dumps(cards, indent=2), encoding="utf-8")
+    print(f"Wrote {len(cards)} flashcards to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a new `learning/flashcard_gen.py` script to turn text into sample flashcards

## Testing
- `python -m py_compile learning/flashcard_gen.py`
- `python learning/flashcard_gen.py data/sample.md --output flashcards.json`

------
https://chatgpt.com/codex/tasks/task_e_683fe5b11ad8832b9c42d760f062f550