### PR TITLE
Implement spaced repetition scheduler

### DIFF
--- a/flashcards.json
+++ b/flashcards.json
@@ -1,0 +1,22 @@
+[
+  {
+    "question": "What does the text say about: '# Page 1\n\nHello PDF page 1\nHello PDF pag'?",
+    "answer": "# Page 1\n\nHello PDF page 1\nHello PDF page 2\nHello PDF page 3"
+  },
+  {
+    "question": "Example question 2",
+    "answer": "Example answer 2"
+  },
+  {
+    "question": "Example question 3",
+    "answer": "Example answer 3"
+  },
+  {
+    "question": "Example question 4",
+    "answer": "Example answer 4"
+  },
+  {
+    "question": "Example question 5",
+    "answer": "Example answer 5"
+  }
+]

--- a/learning/spaced_scheduler.py
+++ b/learning/spaced_scheduler.py
@@ -1,0 +1,67 @@
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from typing import List, Dict
+
+SCHEDULE_DAYS = [1, 3, 7, 14, 30]
+
+
+def load_flashcards(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Flashcards not found: {path}")
+    return json.loads(path.read_text())
+
+
+def build_queue(cards: List[Dict[str, str]], start: date) -> List[Dict[str, str]]:
+    queue: List[Dict[str, str]] = []
+    for card in cards:
+        for days in SCHEDULE_DAYS:
+            due = start + timedelta(days=days)
+            queue.append({
+                "question": card.get("question", ""),
+                "answer": card.get("answer", ""),
+                "due_date": due.isoformat(),
+            })
+    return queue
+
+
+def write_queue(queue: List[Dict[str, str]], path: Path) -> None:
+    path.write_text(json.dumps(queue, indent=2), encoding="utf-8")
+
+
+def read_queue(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        return []
+    return json.loads(path.read_text())
+
+
+def due_today(queue: List[Dict[str, str]], today: date) -> List[Dict[str, str]]:
+    iso = today.isoformat()
+    return [item for item in queue if item.get("due_date") == iso]
+
+
+def main() -> None:
+    flashcards_path = Path("flashcards.json")
+    queue_path = Path("spaced_review_queue.json")
+
+    today = date.today()
+
+    if queue_path.exists():
+        queue = read_queue(queue_path)
+    else:
+        cards = load_flashcards(flashcards_path)
+        queue = build_queue(cards, today)
+        write_queue(queue, queue_path)
+
+    today_cards = due_today(queue, today)
+
+    if today_cards:
+        print("Cards due today:")
+        for i, card in enumerate(today_cards, start=1):
+            print(f"{i}. {card['question']}")
+    else:
+        print("No cards due today.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample_scheduler_output.txt
+++ b/sample_scheduler_output.txt
@@ -1,0 +1,1 @@
+No cards due today.

--- a/spaced_review_queue.json
+++ b/spaced_review_queue.json
@@ -1,0 +1,127 @@
+[
+  {
+    "question": "What does the text say about: '# Page 1\n\nHello PDF page 1\nHello PDF pag'?",
+    "answer": "# Page 1\n\nHello PDF page 1\nHello PDF page 2\nHello PDF page 3",
+    "due_date": "2025-06-05"
+  },
+  {
+    "question": "What does the text say about: '# Page 1\n\nHello PDF page 1\nHello PDF pag'?",
+    "answer": "# Page 1\n\nHello PDF page 1\nHello PDF page 2\nHello PDF page 3",
+    "due_date": "2025-06-07"
+  },
+  {
+    "question": "What does the text say about: '# Page 1\n\nHello PDF page 1\nHello PDF pag'?",
+    "answer": "# Page 1\n\nHello PDF page 1\nHello PDF page 2\nHello PDF page 3",
+    "due_date": "2025-06-11"
+  },
+  {
+    "question": "What does the text say about: '# Page 1\n\nHello PDF page 1\nHello PDF pag'?",
+    "answer": "# Page 1\n\nHello PDF page 1\nHello PDF page 2\nHello PDF page 3",
+    "due_date": "2025-06-18"
+  },
+  {
+    "question": "What does the text say about: '# Page 1\n\nHello PDF page 1\nHello PDF pag'?",
+    "answer": "# Page 1\n\nHello PDF page 1\nHello PDF page 2\nHello PDF page 3",
+    "due_date": "2025-07-04"
+  },
+  {
+    "question": "Example question 2",
+    "answer": "Example answer 2",
+    "due_date": "2025-06-05"
+  },
+  {
+    "question": "Example question 2",
+    "answer": "Example answer 2",
+    "due_date": "2025-06-07"
+  },
+  {
+    "question": "Example question 2",
+    "answer": "Example answer 2",
+    "due_date": "2025-06-11"
+  },
+  {
+    "question": "Example question 2",
+    "answer": "Example answer 2",
+    "due_date": "2025-06-18"
+  },
+  {
+    "question": "Example question 2",
+    "answer": "Example answer 2",
+    "due_date": "2025-07-04"
+  },
+  {
+    "question": "Example question 3",
+    "answer": "Example answer 3",
+    "due_date": "2025-06-05"
+  },
+  {
+    "question": "Example question 3",
+    "answer": "Example answer 3",
+    "due_date": "2025-06-07"
+  },
+  {
+    "question": "Example question 3",
+    "answer": "Example answer 3",
+    "due_date": "2025-06-11"
+  },
+  {
+    "question": "Example question 3",
+    "answer": "Example answer 3",
+    "due_date": "2025-06-18"
+  },
+  {
+    "question": "Example question 3",
+    "answer": "Example answer 3",
+    "due_date": "2025-07-04"
+  },
+  {
+    "question": "Example question 4",
+    "answer": "Example answer 4",
+    "due_date": "2025-06-05"
+  },
+  {
+    "question": "Example question 4",
+    "answer": "Example answer 4",
+    "due_date": "2025-06-07"
+  },
+  {
+    "question": "Example question 4",
+    "answer": "Example answer 4",
+    "due_date": "2025-06-11"
+  },
+  {
+    "question": "Example question 4",
+    "answer": "Example answer 4",
+    "due_date": "2025-06-18"
+  },
+  {
+    "question": "Example question 4",
+    "answer": "Example answer 4",
+    "due_date": "2025-07-04"
+  },
+  {
+    "question": "Example question 5",
+    "answer": "Example answer 5",
+    "due_date": "2025-06-05"
+  },
+  {
+    "question": "Example question 5",
+    "answer": "Example answer 5",
+    "due_date": "2025-06-07"
+  },
+  {
+    "question": "Example question 5",
+    "answer": "Example answer 5",
+    "due_date": "2025-06-11"
+  },
+  {
+    "question": "Example question 5",
+    "answer": "Example answer 5",
+    "due_date": "2025-06-18"
+  },
+  {
+    "question": "Example question 5",
+    "answer": "Example answer 5",
+    "due_date": "2025-07-04"
+  }
+]


### PR DESCRIPTION
## Summary
- add spaced scheduler to turn flashcards into a review queue
- generate example flashcards and review queue
- record sample output of today's run

## Testing
- `python -m py_compile learning/spaced_scheduler.py`
- `python learning/flashcard_gen.py data/sample.md --output flashcards.json`
- `python learning/spaced_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_683fe6bfb2bc832bb76493215475d543