### PR TITLE
Add focus timer utility

### DIFF
--- a/focus_log.json
+++ b/focus_log.json
@@ -1,0 +1,4 @@
+[
+  {"session_length": 25, "completed_at": "2024-01-01T10:00:00Z"},
+  {"session_length": 50, "completed_at": "2024-01-01T11:00:00Z"}
+]

--- a/utils/focus_timer.py
+++ b/utils/focus_timer.py
@@ -1,0 +1,63 @@
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+import sys
+import time
+
+VALID_LENGTHS = {25, 50, 90}
+
+
+def countdown(minutes: int) -> None:
+    """Run a countdown timer for the given minutes."""
+    total_seconds = minutes * 60
+    try:
+        while total_seconds:
+            mins, secs = divmod(total_seconds, 60)
+            timer = f"{mins:02d}:{secs:02d}"
+            print(timer, end="\r", flush=True)
+            time.sleep(1)
+            total_seconds -= 1
+    except KeyboardInterrupt:
+        print("\nTimer cancelled.")
+        sys.exit(1)
+    print("Time's up!            ")
+
+
+def log_session(minutes: int, log_path: Path) -> None:
+    """Append a completed session entry to the log file."""
+    log_entry = {
+        "session_length": minutes,
+        "completed_at": datetime.utcnow().isoformat() + "Z",
+    }
+    if log_path.exists():
+        data = json.loads(log_path.read_text())
+        if not isinstance(data, list):
+            data = []
+    else:
+        data = []
+    data.append(log_entry)
+    log_path.write_text(json.dumps(data, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Focus timer")
+    parser.add_argument(
+        "minutes",
+        type=int,
+        help="Session length in minutes (25, 50, or 90)",
+    )
+    args = parser.parse_args()
+    if args.minutes not in VALID_LENGTHS:
+        print("Invalid session length. Choose from 25, 50, or 90 minutes.")
+        sys.exit(1)
+
+    countdown(args.minutes)
+
+    log_path = Path(__file__).resolve().parents[1] / "focus_log.json"
+    log_session(args.minutes, log_path)
+    print(f"Session logged to {log_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `utils/focus_timer.py` for running Pomodoro sessions
- log completed sessions in `focus_log.json`
- include example log entries

## Testing
- `python3 -m py_compile utils/focus_timer.py`


------
https://chatgpt.com/codex/tasks/task_e_683fe9b341d8832b816c798d1b2f5e78