### PR TITLE
Add summary_writer stub with sample usage

### DIFF
--- a/sample_paragraph.txt
+++ b/sample_paragraph.txt
@@ -1,0 +1,1 @@
+Autodidact AI aims to help individuals structure their learning. This repository contains tools for generating curriculums, creating flashcards, and scheduling reviews. To demonstrate summarization, we provide this simple paragraph. It has more than three sentences to test the output.

--- a/sample_summary_output.txt
+++ b/sample_summary_output.txt
@@ -1,0 +1,1 @@
+This is summary sentence one. This is summary sentence two. This is summary sentence three.

--- a/utils/summary_writer.py
+++ b/utils/summary_writer.py
@@ -1,0 +1,34 @@
+"""Simple summary generator stub."""
+
+from pathlib import Path
+import argparse
+
+
+def generate_summary(paragraph: str) -> str:
+    """Return a three-sentence summary for *paragraph*.
+
+    This implementation is a stub and simply returns a placeholder summary.
+    """
+    return (
+        "This is summary sentence one. "
+        "This is summary sentence two. "
+        "This is summary sentence three."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a summary from a text paragraph")
+    parser.add_argument("input_file", help="Path to a text file containing a single paragraph")
+    parser.add_argument("--output", default="summary.txt", help="File to write the summary to")
+    args = parser.parse_args()
+
+    text = Path(args.input_file).read_text(encoding="utf-8")
+    summary = generate_summary(text)
+
+    out_path = Path(args.output)
+    out_path.write_text(summary, encoding="utf-8")
+    print(f"Wrote summary to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `utils/summary_writer.py` with a stubbed `generate_summary` function
- add sample paragraph text
- show example output from running the script

## Testing
- `python utils/summary_writer.py sample_paragraph.txt --output sample_summary_output.txt`


------
https://chatgpt.com/codex/tasks/task_e_683feb720ab8832bac6554bacc52a4f9