### PR TITLE
Add simple Flask UI for curriculum and focus

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -1,0 +1,64 @@
+import threading
+from datetime import date
+from pathlib import Path
+import json
+from flask import Flask, render_template, request, redirect, url_for, flash
+from werkzeug.utils import secure_filename
+
+import sys
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE_DIR))
+
+from learning import spaced_scheduler
+from utils import focus_timer
+CURRICULUM_PATH = BASE_DIR / "curriculum" / "curriculum.json"
+DATA_DIR = BASE_DIR / "data"
+QUEUE_PATH = BASE_DIR / "spaced_review_queue.json"
+FOCUS_LOG_PATH = BASE_DIR / "focus_log.json"
+
+app = Flask(__name__)
+app.secret_key = "autodidact"  # simple session key
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.route("/curriculum")
+def curriculum():
+    if not CURRICULUM_PATH.exists():
+        return "Curriculum not found", 404
+    data = json.loads(CURRICULUM_PATH.read_text())
+    return render_template("curriculum.html", curriculum=data)
+
+@app.route("/upload", methods=["POST"])
+def upload():
+    file = request.files.get("file")
+    if not file or file.filename == "":
+        flash("No file selected")
+        return redirect(url_for("index"))
+    DATA_DIR.mkdir(exist_ok=True)
+    dest = DATA_DIR / secure_filename(file.filename)
+    file.save(dest)
+    flash(f"Uploaded to {dest}")
+    return redirect(url_for("index"))
+
+@app.route("/flashcards")
+def flashcards():
+    queue = spaced_scheduler.read_queue(QUEUE_PATH)
+    cards = spaced_scheduler.due_today(queue, date.today())
+    return render_template("flashcards.html", cards=cards)
+
+def _run_focus(minutes: int) -> None:
+    focus_timer.countdown(minutes)
+    focus_timer.log_session(minutes, FOCUS_LOG_PATH)
+
+@app.route("/focus", methods=["POST"])
+def focus():
+    minutes = int(request.form.get("minutes", 25))
+    threading.Thread(target=_run_focus, args=(minutes,), daemon=True).start()
+    flash(f"Started a {minutes} minute focus session")
+    return redirect(url_for("index"))
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0")

--- a/ui/templates/curriculum.html
+++ b/ui/templates/curriculum.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Curriculum</title>
+</head>
+<body>
+    <h1>{{ curriculum.goal }}</h1>
+    <ul>
+    {% for topic in curriculum.topics %}
+        <li>
+            <strong>{{ topic.title }}</strong>
+            {% if topic.prerequisites %}
+            <em>Prerequisites: {{ ", ".join(topic.prerequisites) }}</em>
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+    <a href="/">Home</a>
+</body>
+</html>

--- a/ui/templates/flashcards.html
+++ b/ui/templates/flashcards.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Flashcards Due</title>
+</head>
+<body>
+    <h1>Flashcards Due Today</h1>
+    {% if cards %}
+    <ul>
+    {% for card in cards %}
+        <li>{{ card.question }}</li>
+    {% endfor %}
+    </ul>
+    {% else %}
+    <p>No cards due today.</p>
+    {% endif %}
+    <a href="/">Home</a>
+</body>
+</html>

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Autodidact AI</title>
+</head>
+<body>
+    <h1>Autodidact AI</h1>
+    <ul>
+        <li><a href="/curriculum">View Curriculum</a></li>
+        <li><a href="/flashcards">Flashcards Due Today</a></li>
+    </ul>
+    <h2>Upload a PDF or Video</h2>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="file">
+        <button type="submit">Upload</button>
+    </form>
+    <h2>Start Focus Session</h2>
+    <form action="/focus" method="post">
+        <select name="minutes">
+            <option value="25">25 minutes</option>
+            <option value="50">50 minutes</option>
+            <option value="90">90 minutes</option>
+        </select>
+        <button type="submit">Start</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a `ui` folder containing a small Flask application
- allow uploads to `data/`
- list the curriculum tree from `curriculum.json`
- show flashcards due today
- run a focus timer session in a background thread
- add basic HTML templates

## Testing
- `python3 -m py_compile ui/app.py`

------
https://chatgpt.com/codex/tasks/task_e_683fedc5cbc4832bac5eafba114cad64