### PR TITLE
Add video playback and library interface

### DIFF
--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -9,6 +9,7 @@
     <ul>
         <li><a href="/curriculum">View Curriculum</a></li>
         <li><a href="/flashcards">Flashcards Due Today</a></li>
+        <li><a href="/videos">Video Library</a></li>
     </ul>
     <h2>Upload a PDF or Video</h2>
     <form action="/upload" method="post" enctype="multipart/form-data">

--- a/ui/templates/video_library.html
+++ b/ui/templates/video_library.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Video Library</title>
+</head>
+<body>
+    <h1>Video Library</h1>
+    {% if videos %}
+    <table border="1" cellpadding="5">
+        <tr>
+            <th>Video</th>
+            <th>Duration (s)</th>
+            <th>Actions</th>
+        </tr>
+        {% for vid in videos %}
+        <tr>
+            <td>{{ vid.filename }}</td>
+            <td>{{ vid.duration }}</td>
+            <td>
+                <a href="{{ url_for('play_video') }}?video={{ vid.filename }}">Play</a>
+                {% if vid.transcript %}
+                <a href="{{ vid.transcript }}">View Summary</a>
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% else %}
+    <p>No videos found.</p>
+    {% endif %}
+    <a href="/">Home</a>
+</body>
+</html>

--- a/ui/templates/video_player.html
+++ b/ui/templates/video_player.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Video Player</title>
+    <style>
+        .container { display: flex; }
+        .transcript { margin-left: 20px; width: 300px; overflow-y: auto; }
+        .transcript p { margin: 5px 0; }
+    </style>
+</head>
+<body>
+    <h1>{{ video }}</h1>
+    <div class="container">
+        <video width="640" controls>
+            <source src="/video/{{ video }}" type="video/mp4">
+            Your browser does not support the video tag.
+        </video>
+        <div class="transcript">
+            {% for chunk in chunks %}
+            <p>
+                <strong>{{ chunk.start }} - {{ chunk.end }}</strong><br>
+                {{ chunk.text }}<br>
+                <button>Clip this</button>
+                <button>Make flashcard from sentence</button>
+            </p>
+            {% endfor %}
+        </div>
+    </div>
+    <a href="/videos">Back to library</a>
+</body>
+</html>

--- a/videos/video_manager.py
+++ b/videos/video_manager.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import List, Dict, Optional
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+
+def list_videos() -> List[Dict[str, Optional[str]]]:
+    """Return metadata for each mp4 file found in the data directory."""
+    videos: List[Dict[str, Optional[str]]] = []
+    for file in DATA_DIR.glob("*.mp4"):
+        transcript = DATA_DIR / f"{file.stem}_transcript.txt"
+        chunks = DATA_DIR / f"{file.stem}_chunks.json"
+        if chunks.exists():
+            try:
+                chunk_data = json.loads(chunks.read_text())
+                duration = chunk_data[-1].get("end", 0) if chunk_data else 0
+            except json.JSONDecodeError:
+                duration = 0
+        else:
+            duration = 0
+        videos.append(
+            {
+                "filename": file.name,
+                "path": str(file),
+                "transcript": str(transcript) if transcript.exists() else None,
+                "chunks": str(chunks) if chunks.exists() else None,
+                "duration": duration,
+            }
+        )
+    return videos
+
+
+def get_video_metadata(filename: str) -> Dict[str, Optional[str]]:
+    """Return metadata for a single video."""
+    path = DATA_DIR / filename
+    if not path.exists():
+        raise FileNotFoundError(filename)
+    transcript = DATA_DIR / f"{path.stem}_transcript.txt"
+    chunks = DATA_DIR / f"{path.stem}_chunks.json"
+    chunk_data = []
+    if chunks.exists():
+        try:
+            chunk_data = json.loads(chunks.read_text())
+        except json.JSONDecodeError:
+            chunk_data = []
+    return {
+        "filename": filename,
+        "path": str(path),
+        "transcript": transcript.read_text() if transcript.exists() else "",
+        "chunks": chunk_data,
+    }


### PR DESCRIPTION
## Summary
- add `video_manager` utility for gathering video metadata
- create video library and player templates
- update main Flask app with video routes
- link to video library from homepage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683feed5243c832ba517344773c1eb30