### PR TITLE
Add upload UI and ingestion route

### DIFF
--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -11,9 +11,9 @@
         <li><a href="/flashcards">Flashcards Due Today</a></li>
         <li><a href="/videos">Video Library</a></li>
     </ul>
-    <h2>Upload a PDF or Video</h2>
+    <h2>Upload Content</h2>
     <form action="/upload" method="post" enctype="multipart/form-data">
-        <input type="file" name="file">
+        <input type="file" name="file" accept=".pdf,.epub,.mp4">
         <button type="submit">Upload</button>
     </form>
     <h2>Start Focus Session</h2>

--- a/ui/templates/upload_success.html
+++ b/ui/templates/upload_success.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Upload Success</title>
+</head>
+<body>
+    <h1>Upload Successful</h1>
+    <p>Uploaded file: {{ uploaded }}</p>
+    {% if paths %}
+    <h2>Generated Files</h2>
+    <ul>
+    {% for p in paths %}
+        <li>{{ p }}</li>
+    {% endfor %}
+    </ul>
+    {% endif %}
+    <a href="/">Home</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow uploading PDF, EPUB or MP4 files from homepage
- ingest uploaded content using document or video ingestors
- show results on new success page

## Testing
- `python -m py_compile ingestion/document_ingestor.py ingestion/video_ingestor.py ui/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff1712cc8832b96ab4fc95ae0c8e1