### PR TITLE
Add static learning dashboard with key metrics

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -22,6 +22,7 @@ from learning import spaced_scheduler, flashcard_gen
 from utils import focus_timer
 from videos import video_manager
 from ingestion import document_ingestor, video_ingestor
+FLASHCARDS_PATH = BASE_DIR / "flashcards.json"
 CURRICULUM_PATH = BASE_DIR / "curriculum" / "curriculum.json"
 DATA_DIR = BASE_DIR / "data"
 UPLOAD_DIR = DATA_DIR / "uploads"
@@ -98,6 +99,27 @@ def flashcards():
     queue = spaced_scheduler.read_queue(QUEUE_PATH)
     cards = spaced_scheduler.due_today(queue, date.today())
     return render_template("flashcards.html", cards=cards)
+
+
+@app.route("/dashboard")
+def dashboard():
+    docs = list(DATA_DIR.glob("*.md"))
+    videos = list(DATA_DIR.glob("*.mp4"))
+    try:
+        flashcards = json.loads(FLASHCARDS_PATH.read_text()) if FLASHCARDS_PATH.exists() else []
+    except json.JSONDecodeError:
+        flashcards = []
+    try:
+        focus_log = json.loads(FOCUS_LOG_PATH.read_text()) if FOCUS_LOG_PATH.exists() else []
+    except json.JSONDecodeError:
+        focus_log = []
+    metrics = {
+        "docs": len(docs),
+        "videos": len(videos),
+        "flashcards": len(flashcards),
+        "focus_sessions": len(focus_log),
+    }
+    return render_template("dashboard.html", metrics=metrics)
 
 
 @app.route("/generate_flashcards")

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Learning Dashboard</title>
+</head>
+<body>
+    <h1>Learning Dashboard</h1>
+    <ul>
+        <li>Documents ingested: {{ metrics.docs }}</li>
+        <li>Videos ingested: {{ metrics.videos }}</li>
+        <li>Flashcards created: {{ metrics.flashcards }}</li>
+        <li>Deep work sessions: {{ metrics.focus_sessions }}</li>
+    </ul>
+    <a href="/">Home</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dashboard template
- count ingested docs/videos, flashcards, and focus sessions
- show metrics at `/dashboard`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683ff3e8e7f4832b8de43a27b56a7dc3