### PR TITLE
Add per-project storage system for content and progress

### DIFF
--- a/ingestion/video_ingestor.py
+++ b/ingestion/video_ingestor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import sys
 import json
 from pathlib import Path
+import uuid
 
 
 def transcribe(source: str) -> str:
@@ -15,9 +16,12 @@ def create_chunks(transcript: str) -> list[dict[str, float | str]]:
     return [{"start": 0.0, "end": 10.0, "text": transcript}]
 
 
-def ingest_video(source: str) -> tuple[Path, Path]:
-    data_dir = Path("data")
-    data_dir.mkdir(exist_ok=True)
+def ingest_video(source: str, project: str | None = None) -> tuple[Path, Path]:
+    base_dir = Path("data") / "projects"
+    if project is None:
+        project = uuid.uuid4().hex
+    data_dir = base_dir / project
+    data_dir.mkdir(parents=True, exist_ok=True)
 
     transcript_path = data_dir / "transcript.txt"
     chunks_path = data_dir / "transcript_chunks.json"
@@ -32,10 +36,13 @@ def ingest_video(source: str) -> tuple[Path, Path]:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python video_ingestor.py <video.mp4|YouTube URL>")
-        sys.exit(1)
+    import argparse
 
-    t_path, c_path = ingest_video(sys.argv[1])
+    parser = argparse.ArgumentParser(description="Ingest a video")
+    parser.add_argument("source", help="Video file or URL")
+    parser.add_argument("--project", help="Project ID", default=None)
+    args = parser.parse_args()
+
+    t_path, c_path = ingest_video(args.source, args.project)
     print(f"Wrote transcript to {t_path}")
     print(f"Wrote chunks to {c_path}")

--- a/learning/flashcard_gen.py
+++ b/learning/flashcard_gen.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Dict
 
 
+
 def generate_flashcards(text_chunk: str) -> List[Dict[str, str]]:
     """Stub to generate example flashcards from *text_chunk*.
 
@@ -27,14 +28,8 @@ def generate_flashcards(text_chunk: str) -> List[Dict[str, str]]:
     return flashcards
 
 
-def generate_flashcards_from_transcript(transcript_file: str | Path) -> Path:
-    """Generate flashcards from a ``.transcript.json`` file.
-
-    Each chunk's title and lines are concatenated and passed to
-    :func:`generate_flashcards` to create simple question/answer pairs.
-    The resulting list is written to ``flashcards/{video_id}.json`` where
-    ``video_id`` is derived from the transcript filename.
-    """
+def generate_flashcards_from_transcript(transcript_file: str | Path, project: str = "default") -> Path:
+    """Generate flashcards from a ``.transcript.json`` file and store them for a project."""
 
     path = Path(transcript_file)
     data = json.loads(path.read_text())
@@ -53,10 +48,9 @@ def generate_flashcards_from_transcript(transcript_file: str | Path) -> Path:
         if content:
             cards.extend(generate_flashcards(content))
 
-    out_dir = Path("flashcards")
-    out_dir.mkdir(exist_ok=True)
-    video_id = path.stem.split(".")[0]
-    out_path = out_dir / f"{video_id}.json"
+    out_dir = Path("data") / "projects" / project
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "flashcards.json"
     out_path.write_text(json.dumps(cards, indent=2), encoding="utf-8")
     return out_path
 
@@ -67,13 +61,19 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Generate flashcards from a text file")
     parser.add_argument("input_file", help="Path to the text file")
-    parser.add_argument("--output", default="flashcards.json", help="Output JSON file")
+    parser.add_argument(
+        "--project",
+        default="default",
+        help="Project ID to save flashcards under",
+    )
     args = parser.parse_args()
 
     text = Path(args.input_file).read_text(encoding="utf-8")
     cards = generate_flashcards(text)
 
-    out_path = Path(args.output)
+    out_dir = Path("data") / "projects" / args.project
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "flashcards.json"
     out_path.write_text(json.dumps(cards, indent=2), encoding="utf-8")
     print(f"Wrote {len(cards)} flashcards to {out_path}")
 

--- a/learning/spaced_scheduler.py
+++ b/learning/spaced_scheduler.py
@@ -41,8 +41,18 @@ def due_today(queue: List[Dict[str, str]], today: date) -> List[Dict[str, str]]:
 
 
 def main() -> None:
-    flashcards_path = Path("flashcards.json")
-    queue_path = Path("spaced_review_queue.json")
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate or read a spaced review schedule")
+    parser.add_argument(
+        "--project",
+        default="default",
+        help="Project ID for which to generate the schedule",
+    )
+    args = parser.parse_args()
+
+    flashcards_path = Path("data") / "projects" / args.project / "flashcards.json"
+    queue_path = Path("data") / "projects" / args.project / "review_schedule.json"
 
     today = date.today()
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -70,6 +70,7 @@ def curriculum():
 @app.route("/upload", methods=["POST"])
 def upload():
     file = request.files.get("file")
+    project = request.form.get("project") or "default"
     if not file or file.filename == "":
         flash("No file selected")
         return redirect(url_for("index"))
@@ -81,11 +82,11 @@ def upload():
     paths = []
     ext = dest.suffix.lower()
     if ext in {".pdf", ".epub"}:
-        output = document_ingestor.ingest_document(str(dest))
+        output = document_ingestor.ingest_document(str(dest), project)
         app.logger.info(f"Document ingested to {output}")
         paths.append(str(output))
     elif ext == ".mp4":
-        t_path, c_path = video_ingestor.ingest_video(str(dest))
+        t_path, c_path = video_ingestor.ingest_video(str(dest), project)
         app.logger.info(f"Video processed: {t_path}, {c_path}")
         paths.extend([str(t_path), str(c_path)])
     else:

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -13,6 +13,11 @@
     </ul>
     <h2>Upload Content</h2>
     <form action="/upload" method="post" enctype="multipart/form-data">
+        <label for="project">Project:</label>
+        <input type="text" name="project" id="project" list="projects" placeholder="Project ID">
+        <datalist id="projects">
+            <option value="default"></option>
+        </datalist>
         <input type="file" name="file" accept=".pdf,.epub,.mp4">
         <button type="submit">Upload</button>
     </form>

--- a/utils/summary_writer.py
+++ b/utils/summary_writer.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import argparse
+import json
 
 
 def generate_summary(paragraph: str) -> str:
@@ -19,14 +20,20 @@ def generate_summary(paragraph: str) -> str:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate a summary from a text paragraph")
     parser.add_argument("input_file", help="Path to a text file containing a single paragraph")
-    parser.add_argument("--output", default="summary.txt", help="File to write the summary to")
+    parser.add_argument(
+        "--project",
+        default="default",
+        help="Project ID to save the summary under",
+    )
     args = parser.parse_args()
 
     text = Path(args.input_file).read_text(encoding="utf-8")
     summary = generate_summary(text)
 
-    out_path = Path(args.output)
-    out_path.write_text(summary, encoding="utf-8")
+    out_dir = Path("data") / "projects" / args.project
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "summary.json"
+    out_path.write_text(json.dumps({"summary": summary}, indent=2), encoding="utf-8")
     print(f"Wrote summary to {out_path}")
 
 


### PR DESCRIPTION
## Summary
- route summaries to a `/data/projects/<project>/summary.json`
- store flashcards per project
- track spaced-review schedules by project
- allow ingestion scripts to store files under a specific project id
- let uploads specify a project
- add a project selector on the home page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff6ef2008832bb650e2b0f5f2ade9