### PR TITLE
Automate content pipeline from ingestion to flashcard generation

### DIFF
--- a/ui/templates/upload_success.html
+++ b/ui/templates/upload_success.html
@@ -15,6 +15,13 @@
     {% endfor %}
     </ul>
     {% endif %}
+    {% if summary %}
+    <h2>Summary</h2>
+    <p>{{ summary }}</p>
+    {% endif %}
+    {% if flashcard_count %}
+    <p>Flashcards created: {{ flashcard_count }}</p>
+    {% endif %}
     <a href="/">Home</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update upload endpoint to transcribe, summarize and create flashcards
- show generated summary and flashcard count on success page
- expose summary writer util inside app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff91c1204832b94a38f575a60f71a