### PR TITLE
Add post-session reflection summary and logging

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -1,5 +1,5 @@
 import threading
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 import json
 from flask import (
@@ -176,16 +176,103 @@ def generate_flashcards_route():
     out_path = flashcard_gen.generate_flashcards_from_transcript(transcript_path)
     return {"flashcards": str(out_path)}
 
-def _run_focus(minutes: int) -> None:
+def _run_focus(minutes: int, session_type: str, project_id: str) -> None:
+    start = datetime.utcnow()
     focus_timer.countdown(minutes)
-    focus_timer.log_session(minutes, FOCUS_LOG_PATH)
+    end = datetime.utcnow()
+    focus_timer.log_session(start, end, session_type, project_id, FOCUS_LOG_PATH)
 
+
+def _calculate_streak(log: list[dict]) -> int:
+    streak = 0
+    last_date = None
+    for entry in reversed(log):
+        try:
+            start_date = datetime.fromisoformat(entry["start"].replace("Z", "")).date()
+        except Exception:
+            continue
+        if last_date is None:
+            streak = 1
+            last_date = start_date
+            continue
+        diff = (last_date - start_date).days
+        if diff == 0:
+            continue
+        if diff == 1:
+            streak += 1
+            last_date = start_date
+        else:
+            break
+    return streak
+    
 @app.route("/focus", methods=["POST"])
 def focus():
     minutes = int(request.form.get("minutes", 25))
-    threading.Thread(target=_run_focus, args=(minutes,), daemon=True).start()
-    flash(f"Started a {minutes} minute focus session")
+    session_type = request.form.get("session_type", "read")
+    project_id = request.form.get("project_id", "default")
+    threading.Thread(
+        target=_run_focus,
+        args=(minutes, session_type, project_id),
+        daemon=True,
+    ).start()
+    flash(
+        f"Started a {minutes} minute {session_type} session for project {project_id}"
+    )
     return redirect(url_for("index"))
+
+
+@app.route("/session_summary", methods=["GET", "POST"])
+def session_summary():
+    if not FOCUS_LOG_PATH.exists():
+        return "No sessions", 404
+    try:
+        log = json.loads(FOCUS_LOG_PATH.read_text())
+        if not isinstance(log, list):
+            log = []
+    except json.JSONDecodeError:
+        log = []
+    if not log:
+        return "No sessions", 404
+    last = log[-1]
+    streak = _calculate_streak(log)
+    total_time = last.get("session_length")
+    session_type = last.get("session_type", "")
+    project_id = last.get("project_id", "default")
+
+    if request.method == "POST":
+        surprised = request.form.get("surprised", "")
+        revisit = request.form.get("revisit", "")
+        out_dir = DATA_DIR / "projects" / project_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+        ref_path = out_dir / "reflections.json"
+        if ref_path.exists():
+            try:
+                reflections = json.loads(ref_path.read_text())
+                if not isinstance(reflections, list):
+                    reflections = []
+            except json.JSONDecodeError:
+                reflections = []
+        else:
+            reflections = []
+        reflections.append(
+            {
+                "start": last.get("start"),
+                "end": last.get("end"),
+                "surprised": surprised,
+                "revisit": revisit,
+            }
+        )
+        ref_path.write_text(json.dumps(reflections, indent=2), encoding="utf-8")
+        flash("Reflection saved")
+        return redirect(url_for("index"))
+
+    return render_template(
+        "session_summary.html",
+        total_time=total_time,
+        session_type=session_type,
+        streak=streak,
+        project_id=project_id,
+    )
 
 
 @app.route("/clip", methods=["POST"])

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -23,6 +23,14 @@
     </form>
     <h2>Start Focus Session</h2>
     <form action="/focus" method="post">
+        <label for="project_id">Project:</label>
+        <input type="text" name="project_id" id="project_id" placeholder="Project ID" value="default">
+        <label for="session_type">Activity:</label>
+        <select name="session_type" id="session_type">
+            <option value="read">Read</option>
+            <option value="build">Build</option>
+            <option value="review">Review</option>
+        </select>
         <select name="minutes">
             <option value="25">25 minutes</option>
             <option value="50">50 minutes</option>

--- a/ui/templates/session_summary.html
+++ b/ui/templates/session_summary.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Session Summary</title>
+</head>
+<body>
+    <h1>Session Summary</h1>
+    <p>Activity: {{ session_type }}</p>
+    <p>Total time: {{ total_time }} minutes</p>
+    <p>Current streak: {{ streak }} days</p>
+    <form method="post">
+        <label for="surprised">What surprised you?</label><br>
+        <textarea name="surprised" id="surprised" rows="3" cols="40"></textarea><br>
+        <label for="revisit">What will you revisit next session?</label><br>
+        <textarea name="revisit" id="revisit" rows="3" cols="40"></textarea><br>
+        <button type="submit">Save Reflection</button>
+    </form>
+    <a href="/">Home</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- capture start/end time, project, and activity type when logging focus sessions
- allow specifying project and session type from the home page
- add `/session_summary` route to show latest session details and collect reflections
- record reflections to `data/projects/<project>/reflections.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff9f9a330832b9d6e307aae37d93b